### PR TITLE
Add sample for successful compilation with Android Databinding

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,4 @@
+build --experimental_google_legacy_api
+build --experimental_android_databinding_v2
+build --android_databinding_use_v3_4_args
+build --android_databinding_use_androidx

--- a/BUILD
+++ b/BUILD
@@ -14,25 +14,33 @@ kt_compiler_plugin(
 
 kt_android_library(
     name = "app_lib",
+    srcs = glob(["src/main/java/**/*.kt"]),
+    custom_package = "com.example.databinding.lib", # All databinding targets must have unique package name
     enable_data_binding = True,
-    custom_package = "com.example.databinding",
-    srcs = glob(["src/main/java/**/*.kt",]),
-    resource_files = glob(["src/main/res/**/*"]),
     manifest = "src/main/AndroidManifest.xml",
-    deps = [
-        "@maven//:com_squareup_moshi_moshi",
-    ],
     plugins = [
         ":moshi_kotlin_codegen",
-    ]
+    ],
+    resource_files = glob(["src/main/res/**/*"]),
+    deps = [
+        "@maven//:androidx_annotation_annotation",
+        "@maven//:androidx_databinding_databinding_adapters",
+        "@maven//:androidx_databinding_databinding_common",
+        "@maven//:androidx_databinding_databinding_runtime",
+        "@maven//:com_squareup_moshi_moshi",
+    ],
 )
 
 android_binary(
     name = "app",
-    enable_data_binding = True,
     custom_package = "com.example.databinding",
+    enable_data_binding = True,
     manifest = "src/main/AndroidManifest.xml",
     deps = [
         ":app_lib",
+        "@maven//:androidx_annotation_annotation",
+        "@maven//:androidx_databinding_databinding_adapters",
+        "@maven//:androidx_databinding_databinding_common",
+        "@maven//:androidx_databinding_databinding_runtime",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 RULES_JVM_EXTERNAL_TAG = "4.2"
+
 http_archive(
     name = "rules_jvm_external",
     sha256 = "cd1a77b7b02e8e008439ca76fd34f5b07aecb8c752961f9640dea15e9e5ba1ca",
@@ -10,10 +11,20 @@ http_archive(
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
+
+bind(
+    name = "databinding_annotation_processor",
+    actual = "//tools:compiler_annotation_processor",
+)
+
 maven_install(
     artifacts = [
         "com.squareup.moshi:moshi:1.9.2",
         "com.squareup.moshi:moshi-kotlin-codegen:1.9.2",
+        "androidx.databinding:databinding-adapters:3.4.2",
+        "androidx.databinding:databinding-common:3.4.2",
+        "androidx.databinding:databinding-compiler:3.4.2",
+        "androidx.databinding:databinding-runtime:3.4.2",
     ],
     repositories = [
         "https://jcenter.bintray.com/",
@@ -22,9 +33,10 @@ maven_install(
     ],
 )
 
-
 android_sdk_repository(
-  name = "androidsdk",
+    name = "androidsdk",
+    api_level = 30,
+    build_tools_version = "30.0.3", # Build tools 31+ is not supported https://github.com/bazelbuild/bazel/issues/10240#issuecomment-884419566
 )
 
 http_archive(
@@ -34,7 +46,9 @@ http_archive(
 )
 
 load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
+
 kotlin_repositories()
 
 load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
+
 kt_register_toolchains()

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.databinding">
+    package="com.example.databinding.lib">
     <uses-sdk
         android:minSdkVersion="19"
         android:targetSdkVersion="25" />
@@ -7,7 +7,6 @@
     <application>
         <activity
             android:name="com.example.databinding.MainActivity"
-            android:label="@string/app_name"
             android:icon="@mipmap/ic_launcher"
             android:label="@string/app_name"
             android:theme="@style/AppTheme">

--- a/src/main/java/com/example/databinding/MainActivity.kt
+++ b/src/main/java/com/example/databinding/MainActivity.kt
@@ -1,14 +1,14 @@
 package com.example.databinding
 
-import android.databinding.DataBindingUtil
+import androidx.databinding.DataBindingUtil
 import android.widget.TextView
 import android.app.Activity
 import android.os.Bundle
-import com.example.databinding.R
-import com.example.databinding.databinding.ActivityMainBinding
+import com.example.databinding.lib.R
+import com.example.databinding.lib.databinding.ActivityMainBinding
 
 class MainActivity : Activity() {
-    override fun onCreate(savedInstanceState: Bundle) {
+    override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val binding: ActivityMainBinding = DataBindingUtil.setContentView(this, R.layout.activity_main)
     }

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,0 +1,9 @@
+java_plugin(
+    name = "compiler_annotation_processor",
+    generates_api = True,
+    processor_class = "android.databinding.annotationprocessor.ProcessDataBinding",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@bazel_tools//src/tools/android/java/com/google/devtools/build/android:all_android_tools",
+    ],
+)


### PR DESCRIPTION
Databinding at the moment requires few additional steps to be able to successfully compile.

Namely

- `android.databinding.annotationprocessor.ProcessDataBinding` should be bound from `@bazel_tools//src/tools/android/java/com/google/devtools/build/android:all_android_tools`
- All targets using databinding should add databinding dependencies
- Experimental flags should be passed to `build` command.
- Two databinding targets cannot have same package names. 

Misc:

`@BindingAdapter`s written in Kotlin is not supported at the moment, please refer to an implementation at https://github.com/grab/grab-bazel-common#databinding for a solution.

Build

```
bazel build //:app
```